### PR TITLE
feat: export form results to org-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bbin install .
 
 Then you can run:
 ```bash
-bb-form form.json [--values values.json] [--out output.json] [field1:value1 ...]
+bb-form form.json [--values values.json] [--out output.json] [--org output.org] [field1:value1 ...]
 ```
 
 # User Interface Features
@@ -72,7 +72,7 @@ The `bb.edn` file is configured for bbin compatibility:
 # Manual Usage (without bbin)
 
 ```bash
-bb src/com/drbinhthanh/bb_form.clj form.json [--values values.json] [--out output.json] [field1:value1 ...]
+bb src/com/drbinhthanh/bb_form.clj form.json [--values values.json] [--out output.json] [--org output.org] [field1:value1 ...]
 ```
 
 ## Usage Examples
@@ -87,8 +87,14 @@ bb-form form_sample.json --values values.json
 # Form with custom output file
 bb-form form_sample.json --out my_result.json
 
+# Form with Org-mode export
+bb-form form_sample.json --org result.org
+
 # Form with both values and output
 bb-form form_sample.json --values values.json --out custom_output.json
+
+# Form with values, output and org
+bb-form form_sample.json --values values.json --out custom_output.json --org result.org
 
 # Form with values from command line
 bb-form form_sample.json name:"Nguyen Van A" age:25

--- a/README.vi.md
+++ b/README.vi.md
@@ -21,7 +21,7 @@ bbin install .
 
 Sau đó bạn có thể chạy lệnh:
 ```bash
-bb-form form.json [--values values.json] [--out output.json] [field1:value1 ...]
+bb-form form.json [--values values.json] [--out output.json] [--org output.org] [field1:value1 ...]
 ```
 
 # Tính năng giao diện người dùng
@@ -70,7 +70,7 @@ File `bb.edn` được cấu hình để tương thích với bbin:
 # Hướng dẫn sử dụng thủ công (không qua bbin)
 
 ```bash
-bb src/com/drbinhthanh/bb_form.clj form.json [--values values.json] [--out output.json] [field1:value1 ...]
+bb src/com/drbinhthanh/bb_form.clj form.json [--values values.json] [--out output.json] [--org output.org] [field1:value1 ...]
 ```
 
 ## Ví dụ sử dụng
@@ -85,8 +85,14 @@ bb-form form_sample.json --values values.json
 # Chạy form với output file tùy chỉnh
 bb-form form_sample.json --out my_result.json
 
+# Chạy form xuất ra Org-mode
+bb-form form_sample.json --org result.org
+
 # Chạy form với cả values và output
 bb-form form_sample.json --values values.json --out custom_output.json
+
+# Chạy form với values, output và org
+bb-form form_sample.json --values values.json --out custom_output.json --org result.org
 
 # Chạy form với giá trị từ command line
 bb-form form_sample.json name:"Nguyễn Văn A" age:25

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,7 @@
 {:deps {io.github.drringo/bb-form {:local/root "."}
         cheshire/cheshire {:mvn/version "5.11.0"}
-        babashka/process {:mvn/version "0.5.22"}}
- :paths [".","src"] 
+        babashka/process {:mvn/version "0.5.22"}
+        org-crud/org-crud {:mvn/version "0.3.2"}}
+ :paths [".","src"]
  :bbin/bin {bb-form {:main-opts ["-m" "com.drbinhthanh.bb-form"]}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,3 @@
 {:deps {cheshire/cheshire {:mvn/version "5.11.0"}
-        babashka/process {:mvn/version "0.5.22"}}} 
+        babashka/process {:mvn/version "0.5.22"}
+        org-crud/org-crud {:mvn/version "0.3.2"}}}

--- a/src/com/drbinhthanh/bb_form.clj
+++ b/src/com/drbinhthanh/bb_form.clj
@@ -2,7 +2,8 @@
   (:require [babashka.process :refer [shell]]
             [cheshire.core :as json]
             [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [org-crud.core :as org]))
 
 ;; Atom để lưu trữ tất cả câu trả lời của form
 (def answers (atom {}))
@@ -296,6 +297,23 @@
     (ask-field field [:selectedByUser] form)))
 
 ;; -------------------------------
+;; Org export
+;; -------------------------------
+
+(defn- value->prop [v]
+  (if (or (map? v) (sequential? v))
+    (json/generate-string v)
+    (str v)))
+
+(defn export-to-org [org-path data]
+  (let [props (into {} (map (fn [[k v]] [(name k) (value->prop v)]) data))
+        node {:title "Form Result"
+              :level 1
+              :properties props}
+        content (org/nodes->string [node])]
+    (spit org-path (str content "\n") :append true)))
+
+;; -------------------------------
 ;; CLI entry point (from run-form.clj)
 ;; -------------------------------
 
@@ -307,7 +325,7 @@
        (map (fn [[k v]] [(keyword k) v]))
        (into {})))
 
-;; Hàm parse các options từ command line (--values, --out)
+;; Hàm parse các options từ command line (--values, --out, --org)
 (defn parse-options [args]
   (loop [args args
          opts {}]
@@ -329,6 +347,13 @@
             (recur (drop 1 rest)
                    (assoc opts :output-file (first rest))))
 
+          ;; Parse option --org
+          (= k "--org")
+          (if (empty? rest)
+            (do (println "❌ Thiếu file org sau --org") (System/exit 1))
+            (recur (drop 1 rest)
+                   (assoc opts :org-file (first rest))))
+
           ;; Bỏ qua các argument không phải option
           (str/starts-with? k "--")
           (do (println (str "❌ Option không được hỗ trợ: " k)) (System/exit 1))
@@ -344,7 +369,7 @@
                                    (not (str/includes? % ":"))
                                    (str/ends-with? % ".json")) args))
         ;; Parse options từ tất cả arguments
-        {:keys [values-file kv-args output-file]} (parse-options args)
+        {:keys [values-file kv-args output-file org-file]} (parse-options args)
         kv-values (parse-kv-args kv-args)
         ;; Load giá trị mặc định từ file JSON nếu có
         json-values (if values-file
@@ -352,7 +377,8 @@
                       {})
         ;; Merge các giá trị từ command line và file JSON
         prefilled (merge json-values kv-values)
-        output-path (or output-file "result.json")]
+        output-path (or output-file "result.json")
+        org-path org-file]
     
     ;; Kiểm tra xem có file form không
     (if-not form-file
@@ -365,14 +391,22 @@
         (swap! answers update :selectedByUser merge prefilled)
         ;; Chạy form
         (run-form form)
-        ;; Tạo thư mục nếu chưa tồn tại (chỉ khi có path)
+        ;; Tạo thư mục nếu chưa tồn tại cho các file xuất
         (let [output-file (io/file output-path)
               parent-dir (.getParentFile output-file)]
           (when parent-dir
             (.mkdirs parent-dir)))
+        (when org-path
+          (let [org-file (io/file org-path)
+                org-parent (.getParentFile org-file)]
+            (when org-parent (.mkdirs org-parent))))
         ;; Lưu kết quả ra file JSON
         (spit output-path (json/generate-string @answers {:pretty true}))
-        (println (str "\n💾 Đã lưu kết quả vào " output-path))))))
+        (println (str "\n💾 Đã lưu kết quả vào " output-path))
+        ;; Xuất ra file org nếu được yêu cầu
+        (when org-path
+          (export-to-org org-path (:selectedByUser @answers))
+          (println (str "📝 Đã ghi kết quả vào " org-path)))))))
 
 ;; Gọi hàm main với command line arguments
 (when (= *file* (System/getProperty "babashka.file"))


### PR DESCRIPTION
## Summary
- add optional `--org` flag to export filled form to an Org-mode file
- write org data as properties using org-crud
- document org export in English and Vietnamese READMEs

## Testing
- `bb --version` *(fails: command not found)*
- `clojure -M:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4a83b2f0832d8b12b4d5e6495feb